### PR TITLE
FC01_Feature:  Audit Logging

### DIFF
--- a/samples/FastCrud.Samples.Api/Data/AppDbContext.cs
+++ b/samples/FastCrud.Samples.Api/Data/AppDbContext.cs
@@ -7,4 +7,5 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 {
     public DbSet<Customer> Customers => Set<Customer>();
     public DbSet<Order> Orders => Set<Order>();
+    public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
 }

--- a/samples/FastCrud.Samples.Api/Data/AppDbContext.cs
+++ b/samples/FastCrud.Samples.Api/Data/AppDbContext.cs
@@ -8,4 +8,18 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<Customer> Customers => Set<Customer>();
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<AuditEntry>(entity =>
+        {
+            entity.Property(e => e.OldValues)
+                .HasColumnType("nvarchar(max)");
+
+            entity.Property(e => e.NewValues)
+                .HasColumnType("nvarchar(max)");
+        });
+    }
 }

--- a/samples/FastCrud.Samples.Api/Data/AppDbContext.cs
+++ b/samples/FastCrud.Samples.Api/Data/AppDbContext.cs
@@ -1,5 +1,6 @@
 using FastCrud.Samples.Api.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FastCrud.Samples.Api.Data;
 

--- a/samples/FastCrud.Samples.Api/Dtos/AuditLogDto.cs
+++ b/samples/FastCrud.Samples.Api/Dtos/AuditLogDto.cs
@@ -1,0 +1,15 @@
+﻿namespace FastCrud.Samples.Api.Dtos
+{
+    public record AuditLogDto(
+       object Id,
+       string Entity,
+       string EntityId,
+       string Action,
+       string Timestamp,
+       string User,
+       string? OldValues,
+       string? NewValues
+   );
+
+    public record AuditLogsResponse(int TotalLogs, IEnumerable<AuditLogDto> Logs);
+}

--- a/samples/FastCrud.Samples.Api/FastCrud.Samples.Api.csproj
+++ b/samples/FastCrud.Samples.Api/FastCrud.Samples.Api.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="FluentValidation" />
   </ItemGroup>

--- a/samples/FastCrud.Samples.Api/Models/AuditEntry.cs
+++ b/samples/FastCrud.Samples.Api/Models/AuditEntry.cs
@@ -1,0 +1,18 @@
+﻿using FastCrud.Abstractions.Abstractions;
+using FastCrud.Abstractions.Primitives;
+
+namespace FastCrud.Samples.Api.Models
+{
+    public sealed class AuditEntry : IAuditEntry
+    {
+        public long Id { get; set; }
+        public string EntityName { get; set; } = default!;
+        public string EntityId { get; set; } = default!;
+        public AuditAction Action { get; set; }
+        public string? OldValues { get; set; }
+        public string? NewValues { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+        public string? UserId { get; set; }
+        public string? UserName { get; set; }
+    }
+}

--- a/samples/FastCrud.Samples.Api/Program.cs
+++ b/samples/FastCrud.Samples.Api/Program.cs
@@ -34,6 +34,7 @@ builder.Services.UseFluentValidationAdapter();
 builder.Services.AddEfRepository<Customer, Guid, AppDbContext>();
 builder.Services.AddEfRepository<Order, Guid, AppDbContext>();
 
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
@@ -66,6 +67,12 @@ using (var scope = app.Services.CreateScope())
 
 app.UseSwagger();
 app.UseSwaggerUI();
+
+app.MapAuditLogs<AuditEntry>(
+    "/api/audit-logs",
+    tagName: nameof(AuditEntry),
+    groupName: "v1"
+);
 
 // Map CRUD endpoints for entities using FastCrud.
 app.MapFastCrud<Customer, Guid, CustomerCreateDto, CustomerUpdateDto, CustomerReadDto>(

--- a/samples/FastCrud.Samples.Api/Program.cs
+++ b/samples/FastCrud.Samples.Api/Program.cs
@@ -1,4 +1,4 @@
-﻿using FastCrud.Core.DI;
+using FastCrud.Core.DI;
 using FastCrud.Mapping.Mapster.DI;
 using FastCrud.Persistence.EFCore;
 using FastCrud.Persistence.EFCore.DI;
@@ -68,7 +68,7 @@ using (var scope = app.Services.CreateScope())
 app.UseSwagger();
 app.UseSwaggerUI();
 
-app.MapAuditLogs<AuditEntry>(
+app.MapAuditLogs<AuditEntry, AppDbContext>(
     "/api/audit-logs",
     tagName: nameof(AuditEntry),
     groupName: "v1"

--- a/samples/FastCrud.Samples.Api/Program.cs
+++ b/samples/FastCrud.Samples.Api/Program.cs
@@ -70,6 +70,8 @@ app.UseSwaggerUI();
 
 app.MapAuditLogs<AuditEntry, AppDbContext>(
     "/api/audit-logs",
+    includeEntities: null,
+    excludeEntities: null,
     tagName: nameof(AuditEntry),
     groupName: "v1"
 );

--- a/src/FastCrud.Abstractions/Abstractions/IAuditEntry.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IAuditEntry.cs
@@ -1,0 +1,16 @@
+﻿using FastCrud.Abstractions.Primitives;
+
+namespace FastCrud.Abstractions.Abstractions
+{
+    public interface IAuditEntry
+    {
+        string EntityName { get; set; }
+        string EntityId { get; set; }
+        AuditAction Action { get; set; }
+        string? OldValues { get; set; }
+        string? NewValues { get; set; }
+        DateTime Timestamp { get; set; }
+        string? UserId { get; set; }
+        string? UserName { get; set; }
+    }
+}

--- a/src/FastCrud.Abstractions/Abstractions/IAuditQueryService.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IAuditQueryService.cs
@@ -1,0 +1,8 @@
+﻿namespace FastCrud.Abstractions.Abstractions
+{
+    public interface IAuditQueryService<TAuditEntry>
+    where TAuditEntry : class, IAuditEntry
+    {
+        Task<object> GetRecentAuditLogsAsync(int count = 100, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/FastCrud.Abstractions/Abstractions/IAuditQueryService.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IAuditQueryService.cs
@@ -1,8 +1,9 @@
-﻿namespace FastCrud.Abstractions.Abstractions
+namespace FastCrud.Abstractions.Abstractions
 {
     public interface IAuditQueryService<TAuditEntry>
     where TAuditEntry : class, IAuditEntry
     {
         Task<object> GetRecentAuditLogsAsync(int count = 100, CancellationToken cancellationToken = default);
+        Task<object> GetAuditLogsByEntityAsync(string entityName, int count = 100, CancellationToken cancellationToken = default);
     }
 }

--- a/src/FastCrud.Abstractions/Abstractions/IAuditService.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IAuditService.cs
@@ -1,0 +1,9 @@
+﻿using FastCrud.Abstractions.Primitives;
+
+namespace FastCrud.Abstractions.Abstractions
+{
+    public interface IAuditService
+    {
+        Task LogAsync<T>(T entity, AuditAction action, object? oldValues = null, object? newValues = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/FastCrud.Abstractions/Abstractions/IAuditUserProvider.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IAuditUserProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace FastCrud.Abstractions.Abstractions
+{
+    public interface IAuditUserProvider
+    {
+        (string? UserId, string? UserName) GetCurrentUser();
+    }
+}

--- a/src/FastCrud.Abstractions/Abstractions/IAuditable.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IAuditable.cs
@@ -1,0 +1,10 @@
+﻿namespace FastCrud.Abstractions.Abstractions
+{
+    public interface IAuditable
+    {
+        DateTime CreatedAt { get; set; }
+        string? CreatedBy { get; set; }
+        DateTime? UpdatedAt { get; set; }
+        string? UpdatedBy { get; set; }
+    }
+}

--- a/src/FastCrud.Abstractions/FastCrud.Abstractions.csproj
+++ b/src/FastCrud.Abstractions/FastCrud.Abstractions.csproj
@@ -1,2 +1,1 @@
-<Project Sdk="Microsoft.NET.Sdk">
-</Project>
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/FastCrud.Abstractions/Primitives/AuditAction.cs
+++ b/src/FastCrud.Abstractions/Primitives/AuditAction.cs
@@ -1,0 +1,9 @@
+﻿namespace FastCrud.Abstractions.Primitives
+{
+    public enum AuditAction
+    {
+        Create,
+        Update,
+        Delete
+    }
+}

--- a/src/FastCrud.Core/Services/CrudService.cs
+++ b/src/FastCrud.Core/Services/CrudService.cs
@@ -27,11 +27,6 @@ namespace FastCrud.Core.Services
             await repository.AddAsync(entity, cancellationToken);
             await repository.SaveChangesAsync(cancellationToken);
 
-            if (auditService != null)
-            {
-                await auditService.LogAsync(entity, AuditAction.Create, newValues: entity, cancellationToken: cancellationToken);
-            }
-
             return entity;
         }
 
@@ -40,11 +35,6 @@ namespace FastCrud.Core.Services
             var entity = await repository.FindAsync(id, cancellationToken);
             if (entity != null)
             {
-                if (auditService != null)
-                {
-                    await auditService.LogAsync(entity, AuditAction.Delete, oldValues: entity, cancellationToken: cancellationToken);
-                }
-
                 await repository.DeleteAsync(entity, cancellationToken);
                 await repository.SaveChangesAsync(cancellationToken);
             }
@@ -87,11 +77,6 @@ namespace FastCrud.Core.Services
             await ValidateModelAsync(entity, cancellationToken);
 
             await repository.SaveChangesAsync(cancellationToken);
-
-            if (auditService != null && oldValues != null)
-            {
-                await auditService.LogAsync(entity, AuditAction.Update, oldValues: oldValues, newValues: entity, cancellationToken: cancellationToken);
-            }
 
             return entity;
         }

--- a/src/FastCrud.Core/Services/CrudService.cs
+++ b/src/FastCrud.Core/Services/CrudService.cs
@@ -1,12 +1,7 @@
 using FastCrud.Abstractions.Abstractions;
 using FastCrud.Abstractions.Primitives;
 using FastCrud.Abstractions.Query;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace FastCrud.Core.Services;
 

--- a/src/FastCrud.PersistenceEfCore/DI/AuditServiceCollectionExtensions.cs
+++ b/src/FastCrud.PersistenceEfCore/DI/AuditServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+﻿using FastCrud.Abstractions.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastCrud.Persistence.EFCore.DI;
+
+public static class AuditServiceCollectionExtensions
+{
+    public static IServiceCollection AddEfAuditing<TDbContext, TAuditEntry>(this IServiceCollection services)
+        where TDbContext : DbContext
+        where TAuditEntry : class, IAuditEntry, new()
+    {
+        services.AddScoped<IAuditUserProvider, DefaultAuditUserProvider>();
+        services.AddScoped<EntityAuditingInterceptor<TAuditEntry>>();
+        services.AddScoped<IAuditService>(sp =>
+            new EfAuditService<TDbContext, TAuditEntry>(
+                sp.GetRequiredService<TDbContext>(),
+                sp.GetRequiredService<IAuditUserProvider>()));
+
+        return services;
+    }
+
+    public static IServiceCollection AddCustomAuditUserProvider<TProvider>(this IServiceCollection services)
+        where TProvider : class, IAuditUserProvider
+    {
+        services.AddScoped<IAuditUserProvider, TProvider>();
+        return services;
+    }
+
+    public static IServiceCollection AddEfAuditing<TDbContext>(this IServiceCollection services,
+        Type auditEntryType)
+        where TDbContext : DbContext
+    {
+        if (!typeof(IAuditEntry).IsAssignableFrom(auditEntryType))
+        {
+            throw new ArgumentException($"Type: {auditEntryType.Name} ans IAuditEntry", nameof(auditEntryType));
+        }
+
+        services.AddScoped<IAuditUserProvider, DefaultAuditUserProvider>();
+        var interceptorType = typeof(EntityAuditingInterceptor<>).MakeGenericType(auditEntryType);
+        services.AddScoped(interceptorType);
+
+        services.AddScoped<IAuditService>(sp =>
+        {
+            var auditServiceType = typeof(EfAuditService<,>).MakeGenericType(typeof(TDbContext), auditEntryType);
+            return (IAuditService)Activator.CreateInstance(auditServiceType,
+                sp.GetRequiredService<TDbContext>(),
+                sp.GetRequiredService<IAuditUserProvider>())!;
+        });
+
+        return services;
+    }
+}

--- a/src/FastCrud.PersistenceEfCore/DI/AuditServiceCollectionExtensions.cs
+++ b/src/FastCrud.PersistenceEfCore/DI/AuditServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ public static class AuditServiceCollectionExtensions
     {
         if (!typeof(IAuditEntry).IsAssignableFrom(auditEntryType))
         {
-            throw new ArgumentException($"Type: {auditEntryType.Name} ans IAuditEntry", nameof(auditEntryType));
+            throw new ArgumentException($"Type: {auditEntryType.Name} and IAuditEntry", nameof(auditEntryType));
         }
 
         services.AddScoped<IAuditUserProvider, DefaultAuditUserProvider>();

--- a/src/FastCrud.PersistenceEfCore/DI/AuditServiceCollectionExtensions.cs
+++ b/src/FastCrud.PersistenceEfCore/DI/AuditServiceCollectionExtensions.cs
@@ -17,6 +17,9 @@ public static class AuditServiceCollectionExtensions
                 sp.GetRequiredService<TDbContext>(),
                 sp.GetRequiredService<IAuditUserProvider>()));
 
+        services.AddScoped<IAuditQueryService<TAuditEntry>>(sp =>
+            new EfAuditQueryService<TAuditEntry>(sp.GetRequiredService<TDbContext>()));
+
         return services;
     }
 

--- a/src/FastCrud.PersistenceEfCore/DefaultAuditUserProvider.cs
+++ b/src/FastCrud.PersistenceEfCore/DefaultAuditUserProvider.cs
@@ -1,0 +1,11 @@
+﻿using FastCrud.Abstractions.Abstractions;
+
+namespace FastCrud.Persistence.EFCore;
+
+public sealed class DefaultAuditUserProvider : IAuditUserProvider
+{
+    public (string? UserId, string? UserName) GetCurrentUser()
+    {
+        return ("system", "System");
+    }
+}

--- a/src/FastCrud.PersistenceEfCore/EfAuditQueryService.cs
+++ b/src/FastCrud.PersistenceEfCore/EfAuditQueryService.cs
@@ -1,0 +1,47 @@
+﻿using FastCrud.Abstractions.Abstractions;
+using Microsoft.EntityFrameworkCore;
+
+namespace FastCrud.Persistence.EFCore;
+
+public class EfAuditQueryService<TAuditEntry> : IAuditQueryService<TAuditEntry>
+    where TAuditEntry : class, IAuditEntry
+{
+    private readonly DbContext _context;
+
+    public EfAuditQueryService(DbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<object> GetRecentAuditLogsAsync(int count = 100, CancellationToken cancellationToken = default)
+    {
+        var auditLogs = await _context.Set<TAuditEntry>()
+            .OrderByDescending(x => x.Timestamp)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+
+        var logs = auditLogs.Select(log => new
+        {
+            Id = GetAuditEntryId(log),
+            Entity = log.EntityName,
+            EntityId = log.EntityId.Length > 8 ? log.EntityId[..8] : log.EntityId,
+            Action = log.Action.ToString(),
+            Timestamp = log.Timestamp.ToString("yyyy-MM-dd HH:mm:ss"),
+            User = $"{log.UserName ?? "Unknown"} ({log.UserId ?? "N/A"})",
+            OldValues = log.OldValues,
+            NewValues = log.NewValues
+        });
+
+        return new
+        {
+            TotalLogs = auditLogs.Count,
+            Logs = logs
+        };
+    }
+
+    private static object GetAuditEntryId(IAuditEntry entry)
+    {
+        var idProperty = entry.GetType().GetProperty("Id");
+        return idProperty?.GetValue(entry) ?? 0;
+    }
+}

--- a/src/FastCrud.PersistenceEfCore/EfAuditQueryService.cs
+++ b/src/FastCrud.PersistenceEfCore/EfAuditQueryService.cs
@@ -1,4 +1,4 @@
-﻿using FastCrud.Abstractions.Abstractions;
+using FastCrud.Abstractions.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace FastCrud.Persistence.EFCore;
@@ -34,6 +34,34 @@ public class EfAuditQueryService<TAuditEntry> : IAuditQueryService<TAuditEntry>
 
         return new
         {
+            TotalLogs = auditLogs.Count,
+            Logs = logs
+        };
+    }
+
+    public async Task<object> GetAuditLogsByEntityAsync(string entityName, int count = 100, CancellationToken cancellationToken = default)
+    {
+        var auditLogs = await _context.Set<TAuditEntry>()
+            .Where(x => x.EntityName == entityName)
+            .OrderByDescending(x => x.Timestamp)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+
+        var logs = auditLogs.Select(log => new
+        {
+            Id = GetAuditEntryId(log),
+            Entity = log.EntityName,
+            EntityId = log.EntityId.Length > 8 ? log.EntityId[..8] : log.EntityId,
+            Action = log.Action.ToString(),
+            Timestamp = log.Timestamp.ToString("yyyy-MM-dd HH:mm:ss"),
+            User = $"{log.UserName ?? "Unknown"} ({log.UserId ?? "N/A"})",
+            OldValues = log.OldValues,
+            NewValues = log.NewValues
+        });
+
+        return new
+        {
+            EntityName = entityName,
             TotalLogs = auditLogs.Count,
             Logs = logs
         };

--- a/src/FastCrud.PersistenceEfCore/EfAuditService.cs
+++ b/src/FastCrud.PersistenceEfCore/EfAuditService.cs
@@ -1,0 +1,56 @@
+﻿using FastCrud.Abstractions.Abstractions;
+using FastCrud.Abstractions.Primitives;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace FastCrud.Persistence.EFCore;
+
+public sealed class EfAuditService<TDbContext, TAuditEntry> : IAuditService
+    where TDbContext : DbContext
+    where TAuditEntry : class, IAuditEntry, new()
+{
+    private readonly TDbContext _context;
+    private readonly IAuditUserProvider _userProvider;
+
+    public EfAuditService(TDbContext context, IAuditUserProvider userProvider)
+    {
+        _context = context;
+        _userProvider = userProvider;
+    }
+
+    public async Task LogAsync<T>(T entity, AuditAction action, object? oldValues = null, object? newValues = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var entityId = GetEntityId(entity);
+            if (string.IsNullOrEmpty(entityId)) return;
+
+            var user = _userProvider.GetCurrentUser();
+
+            var auditEntry = new TAuditEntry
+            {
+                EntityName = typeof(T).Name,
+                EntityId = entityId,
+                Action = action,
+                OldValues = oldValues != null ? JsonSerializer.Serialize(oldValues) : null,
+                NewValues = newValues != null ? JsonSerializer.Serialize(newValues) : null,
+                Timestamp = DateTime.UtcNow,
+                UserId = user.UserId,
+                UserName = user.UserName
+            };
+
+            _context.Set<TAuditEntry>().Add(auditEntry);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+        }
+    }
+
+    private static string? GetEntityId<T>(T entity)
+    {
+        var idProperty = typeof(T).GetProperty("Id");
+        return idProperty?.GetValue(entity)?.ToString();
+    }
+}

--- a/src/FastCrud.PersistenceEfCore/EntityAuditingInterceptor .cs
+++ b/src/FastCrud.PersistenceEfCore/EntityAuditingInterceptor .cs
@@ -1,0 +1,215 @@
+﻿using FastCrud.Abstractions.Abstractions;
+using FastCrud.Abstractions.Primitives;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Text.Json;
+
+namespace FastCrud.Persistence.EFCore;
+
+public sealed class EntityAuditingInterceptor<TAuditEntry> : SaveChangesInterceptor
+    where TAuditEntry : class, IAuditEntry, new()
+{
+    private readonly IAuditUserProvider _userProvider;
+
+    public EntityAuditingInterceptor(IAuditUserProvider userProvider)
+    {
+        _userProvider = userProvider;
+    }
+
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        AddAuditEntries(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+    {
+        AddAuditEntries(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private void AddAuditEntries(DbContext? context)
+    {
+        if (context == null) return;
+
+        try
+        {
+            var user = _userProvider.GetCurrentUser();
+            var auditEntries = new List<TAuditEntry>();
+
+            foreach (var entry in context.ChangeTracker.Entries())
+            {
+                if (entry.Entity is IAuditEntry) continue;
+                if (!HasIdProperty(entry.Entity)) continue;
+
+                var auditEntry = CreateAuditEntry(entry, user);
+                if (auditEntry != null)
+                {
+                    auditEntries.Add(auditEntry);
+                }
+                UpdateAuditableFields(entry, user);
+            }
+
+            if (auditEntries.Any())
+            {
+                context.Set<TAuditEntry>().AddRange(auditEntries);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+        }
+    }
+
+    private static bool HasIdProperty(object entity)
+    {
+        return entity.GetType().GetProperty("Id") != null;
+    }
+
+    private TAuditEntry? CreateAuditEntry(EntityEntry entry, (string? UserId, string? UserName) user)
+    {
+        try
+        {
+            var entityName = entry.Entity.GetType().Name;
+            var entityId = GetEntityId(entry);
+
+            if (string.IsNullOrEmpty(entityId)) return null;
+
+            var action = entry.State switch
+            {
+                EntityState.Added => AuditAction.Create,
+                EntityState.Modified => AuditAction.Update,
+                EntityState.Deleted => AuditAction.Delete,
+                _ => (AuditAction?)null
+            };
+
+            if (action == null) return null;
+
+            var auditEntry = new TAuditEntry
+            {
+                EntityName = entityName,
+                EntityId = entityId,
+                Action = action.Value,
+                Timestamp = DateTime.UtcNow,
+                UserId = user.UserId,
+                UserName = user.UserName
+            };
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    auditEntry.NewValues = SerializeValues(entry, entry.CurrentValues);
+                    break;
+                case EntityState.Modified:
+                    var modifiedProperties = entry.Properties
+                        .Where(p => p.IsModified && !p.Metadata.IsPrimaryKey())
+                        .ToList();
+
+                    if (modifiedProperties.Any())
+                    {
+                        auditEntry.OldValues = SerializeModifiedValues(entry, entry.OriginalValues, modifiedProperties);
+                        auditEntry.NewValues = SerializeModifiedValues(entry, entry.CurrentValues, modifiedProperties);
+                    }
+                    break;
+                case EntityState.Deleted:
+                    auditEntry.OldValues = SerializeValues(entry, entry.OriginalValues);
+                    break;
+            }
+
+            return auditEntry;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void UpdateAuditableFields(EntityEntry entry, (string? UserId, string? UserName) user)
+    {
+        if (entry.Entity is not IAuditable auditable) return;
+
+        var now = DateTime.UtcNow;
+        var userName = user.UserName ?? user.UserId ?? "System";
+
+        switch (entry.State)
+        {
+            case EntityState.Added:
+                auditable.CreatedAt = now;
+                auditable.CreatedBy = userName;
+                break;
+            case EntityState.Modified:
+                auditable.UpdatedAt = now;
+                auditable.UpdatedBy = userName;
+                break;
+        }
+    }
+
+    private static string? GetEntityId(EntityEntry entry)
+    {
+        var keyProperty = entry.Properties.FirstOrDefault(p => p.Metadata.IsPrimaryKey());
+        return keyProperty?.CurrentValue?.ToString();
+    }
+
+    private static string? SerializeValues(EntityEntry entry, PropertyValues values)
+    {
+        try
+        {
+            var result = new Dictionary<string, object?>();
+
+            foreach (var property in entry.Properties)
+            {
+                if (property.Metadata.IsForeignKey() ||
+                    property.Metadata.IsShadowProperty() ||
+                    property.Metadata.IsKey()) continue;
+
+                var propertyName = property.Metadata.Name;
+                var value = values[propertyName];
+
+                if (value is DateTime dt)
+                    value = dt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+                result[propertyName] = value;
+            }
+
+            return result.Any() ? JsonSerializer.Serialize(result, new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            }) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? SerializeModifiedValues(EntityEntry entry, PropertyValues values, List<PropertyEntry> modifiedProperties)
+    {
+        try
+        {
+            var result = new Dictionary<string, object?>();
+
+            foreach (var property in modifiedProperties)
+            {
+                var propertyName = property.Metadata.Name;
+                var value = values[propertyName];
+
+                if (value is DateTime dt)
+                    value = dt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+
+                result[propertyName] = value;
+            }
+
+            return result.Any() ? JsonSerializer.Serialize(result, new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            }) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/FastCrud.Web.MinimalApi/AuditEndpointExtensions.cs
+++ b/src/FastCrud.Web.MinimalApi/AuditEndpointExtensions.cs
@@ -1,0 +1,36 @@
+﻿using FastCrud.Abstractions.Abstractions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace FastCrud.Web.MinimalApi;
+
+public static class AuditEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapAuditLogs<TAuditEntry>(
+        this IEndpointRouteBuilder builder,
+        string routePrefix = "/api/audit-logs",
+        string? tagName = null,
+        string? groupName = null)
+        where TAuditEntry : class, IAuditEntry
+    {
+        tagName ??= "Audit";
+        var prefix = routePrefix.StartsWith('/') ? routePrefix : $"/{routePrefix}";
+        var group = builder.MapGroup(prefix).WithTags(tagName);
+
+        if (groupName != null)
+        {
+            group.WithGroupName(groupName);
+        }
+
+        group.MapGet("/", async (
+            IAuditQueryService<TAuditEntry> auditService,
+            CancellationToken ct) =>
+        {
+            var result = await auditService.GetRecentAuditLogsAsync(100, ct);
+            return Results.Ok(result);
+        });
+
+        return builder;
+    }
+}

--- a/src/FastCrud.Web.MinimalApi/AuditEndpointExtensions.cs
+++ b/src/FastCrud.Web.MinimalApi/AuditEndpointExtensions.cs
@@ -2,7 +2,6 @@ using FastCrud.Abstractions.Abstractions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.EntityFrameworkCore;
 using System.Reflection;
 
 namespace FastCrud.Web.MinimalApi;
@@ -12,10 +11,11 @@ public static class AuditEndpointExtensions
     public static IEndpointRouteBuilder MapAuditLogs<TAuditEntry, TDbContext>(
         this IEndpointRouteBuilder builder,
         string routePrefix = "/api/audit-logs",
+        IEnumerable<Type>? includeEntities = null,
+        IEnumerable<Type>? excludeEntities = null,
         string? tagName = null,
         string? groupName = null)
         where TAuditEntry : class, IAuditEntry
-        where TDbContext : DbContext
     {
         tagName ??= "Audit";
         var prefix = routePrefix.StartsWith('/') ? routePrefix : $"/{routePrefix}";
@@ -34,7 +34,8 @@ public static class AuditEndpointExtensions
             return Results.Ok(result);
         });
 
-        var auditableEntities = GetAuditableEntities<TDbContext, TAuditEntry>();
+        var auditableEntities = GetAuditableEntities<TDbContext, TAuditEntry>(includeEntities, excludeEntities);
+
         foreach (var entityName in auditableEntities)
         {
             var entityRoute = $"/{entityName.ToLowerInvariant()}";
@@ -51,26 +52,61 @@ public static class AuditEndpointExtensions
         return builder;
     }
 
-    private static IEnumerable<string> GetAuditableEntities<TDbContext, TAuditEntry>()
-        where TDbContext : DbContext
+    public static IEndpointRouteBuilder MapAuditLogsFor<TAuditEntry, TDbContext>(
+        this IEndpointRouteBuilder builder,
+        string routePrefix,
+        string? tagName = null,
+        string? groupName = null,
+        params Type[] entityTypes)
+        where TAuditEntry : class, IAuditEntry
+    {
+        return MapAuditLogs<TAuditEntry, TDbContext>(
+            builder,
+            routePrefix,
+            includeEntities: entityTypes.Length > 0 ? entityTypes : null,
+            excludeEntities: null,
+            tagName: tagName,
+            groupName: groupName);
+    }
+
+    private static IEnumerable<string> GetAuditableEntities<TDbContext, TAuditEntry>(
+        IEnumerable<Type>? includeEntities = null,
+        IEnumerable<Type>? excludeEntities = null)
         where TAuditEntry : class, IAuditEntry
     {
         var dbContextType = typeof(TDbContext);
         var auditEntryType = typeof(TAuditEntry);
         var iAuditEntryType = typeof(IAuditEntry);
 
-        var dbSetProperties = dbContextType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        var allEntityTypes = dbContextType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
             .Where(p => p.PropertyType.IsGenericType &&
-                       p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>))
+                       p.PropertyType.GetGenericTypeDefinition().FullName == "Microsoft.EntityFrameworkCore.DbSet`1")
             .Select(p => p.PropertyType.GetGenericArguments()[0])
-            .Where(entityType => 
+            .Where(entityType =>
                 !entityType.IsAssignableTo(iAuditEntryType) &&
                 entityType != auditEntryType &&
                 entityType.GetProperty("Id") != null)
+            .ToList();
+
+        if (includeEntities != null && includeEntities.Any())
+        {
+            var includeSet = new HashSet<Type>(includeEntities);
+            allEntityTypes = allEntityTypes
+                .Where(t => includeSet.Contains(t))
+                .ToList();
+        }
+
+        if (excludeEntities != null && excludeEntities.Any())
+        {
+            var excludeSet = new HashSet<Type>(excludeEntities);
+            allEntityTypes = allEntityTypes
+                .Where(t => !excludeSet.Contains(t))
+                .ToList();
+        }
+
+        return allEntityTypes
             .Select(entityType => entityType.Name)
             .Distinct()
             .OrderBy(name => name);
-
-        return dbSetProperties;
     }
 }

--- a/src/FastCrud.Web.MinimalApi/AuditEndpointExtensions.cs
+++ b/src/FastCrud.Web.MinimalApi/AuditEndpointExtensions.cs
@@ -1,18 +1,21 @@
-﻿using FastCrud.Abstractions.Abstractions;
+using FastCrud.Abstractions.Abstractions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using System.Reflection;
 
 namespace FastCrud.Web.MinimalApi;
 
 public static class AuditEndpointExtensions
 {
-    public static IEndpointRouteBuilder MapAuditLogs<TAuditEntry>(
+    public static IEndpointRouteBuilder MapAuditLogs<TAuditEntry, TDbContext>(
         this IEndpointRouteBuilder builder,
         string routePrefix = "/api/audit-logs",
         string? tagName = null,
         string? groupName = null)
         where TAuditEntry : class, IAuditEntry
+        where TDbContext : DbContext
     {
         tagName ??= "Audit";
         var prefix = routePrefix.StartsWith('/') ? routePrefix : $"/{routePrefix}";
@@ -31,6 +34,43 @@ public static class AuditEndpointExtensions
             return Results.Ok(result);
         });
 
+        var auditableEntities = GetAuditableEntities<TDbContext, TAuditEntry>();
+        foreach (var entityName in auditableEntities)
+        {
+            var entityRoute = $"/{entityName.ToLowerInvariant()}";
+            group.MapGet(entityRoute, async (
+                IAuditQueryService<TAuditEntry> auditService,
+                CancellationToken ct) =>
+            {
+                var result = await auditService.GetAuditLogsByEntityAsync(entityName, 100, ct);
+                return Results.Ok(result);
+            })
+            .WithName($"GetAuditLogsFor{entityName}");
+        }
+
         return builder;
+    }
+
+    private static IEnumerable<string> GetAuditableEntities<TDbContext, TAuditEntry>()
+        where TDbContext : DbContext
+        where TAuditEntry : class, IAuditEntry
+    {
+        var dbContextType = typeof(TDbContext);
+        var auditEntryType = typeof(TAuditEntry);
+        var iAuditEntryType = typeof(IAuditEntry);
+
+        var dbSetProperties = dbContextType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType.IsGenericType &&
+                       p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>))
+            .Select(p => p.PropertyType.GetGenericArguments()[0])
+            .Where(entityType => 
+                !entityType.IsAssignableTo(iAuditEntryType) &&
+                entityType != auditEntryType &&
+                entityType.GetProperty("Id") != null)
+            .Select(entityType => entityType.Name)
+            .Distinct()
+            .OrderBy(name => name);
+
+        return dbSetProperties;
     }
 }


### PR DESCRIPTION
# Audit Logging 

**linked issue: https://github.com/ashkanRmk/FastCrud/issues/1**


Hi Mr. Rahmani 🌹  Thank you for the recent updates, it is great and I use FastCrud in my daily works.
 I apologize for the extended development time on this implementation I wanted to ensure it follows the project's architecture patterns correctly and maintains the high quality standards of FastCrud. 

# Features
This PR adds audit logging functionality to FastCrud, enabling automatic tracking of all CRUD operations including Create, Update, Delete on entities. 

###  New Endpoint for Audit

```
app.MapAuditLogs<AuditEntry>(
    "/api/audit-logs",
    tagName: "Audit",
    groupName: "v1"
);
```

### Response Example 
However, the responses need refinement. I want to confirm the implementation on your end, and then, if permissible, I will proceed with some refactoring.

<img width="1733" height="417" alt="image" src="https://github.com/user-attachments/assets/0c31f52a-2e30-4224-ace0-bed7ed763e55" />


# 🔴 Architecture and Patterns Details 

### 1. Capture approach: 
 **EF Core SaveChanges Interceptor  and Manual Service**  (Manual Service for `EfAuditService<TDbContext, TAuditEntry>` )

```
public sealed class EntityAuditingInterceptor<TAuditEntry> : SaveChangesInterceptor
{
    public override InterceptionResult<int> SavingChanges()
    public override ValueTask<InterceptionResult<int>> SavingChangesAsync()
}
```
 
### 2. Persistence: 

 **This code implemented with sync / async approach and audit entries will save immediately and doesn't go to the queue for processing**

```
public override InterceptionResult<int> SavingChanges()

public override ValueTask<InterceptionResult<int>> SavingChangesAsync()

```

# 🔍 Performance and Reliability

### 1. Batching / Deferred
**We used both in the _EntityAuditingInterceptor_ but we don't heve neither in _EfAuditService_**

  ✅EntityAuditingInterceptor 

```
private void AddAuditEntries(DbContext? context)
{
    var auditEntries = new List<TAuditEntry>();
    
    foreach (var entry in context.ChangeTracker.Entries())
    {
        auditEntries.Add(auditEntry);
    }
    
    if (auditEntries.Any())
    {
        context.Set<TAuditEntry>().AddRange(auditEntries); 
    }
}

```

❌ EfAuditService

```
public async Task LogAsync<T>(T entity)
{
    _context.Set<TAuditEntry>().Add(auditEntry); 
    await _context.SaveChangesAsync(cancellationToken); 
}
```

### 2. Transaction coupling

✅EntityAuditingInterceptor  has Same Transaction

```
private void AddAuditEntries(DbContext? context)
{
    context.Set<TAuditEntry>().AddRange(auditEntries);
}

```

 ❌ EfAuditService has Fire-and-forget

```
public async Task LogAsync<T>(T entity)
{
    _context.Set<TAuditEntry>().Add(auditEntry);
    await _context.SaveChangesAsync(cancellationToken);
}

```

❌  CrudServices has Fire-and-forget:

```
async Task<TAgg> CreateAsync(object input, CancellationToken cancellationToken)
{
    await repository.AddAsync(entity, cancellationToken);
    await repository.SaveChangesAsync(cancellationToken);
    
    if (auditService != null)
    {
        await auditService.LogAsync(entity, AuditAction.Create,);
    }
}
```

### 3. Handling large diffs (field-level vs full snapshot)
**We used field-level tracking.**

```
case EntityState.Modified:
    var modifiedProperties = entry.Properties
        .Where(p => p.IsModified && !p.Metadata.IsPrimaryKey()) 
        .ToList();
        
    auditEntry.OldValues = SerializeModifiedValues(entry, entry.OriginalValues, modifiedProperties);
    auditEntry.NewValues = SerializeModifiedValues(entry, entry.CurrentValues, modifiedProperties);
```

```
if (property.Metadata.IsForeignKey() ||
    property.Metadata.IsShadowProperty() ||
    property.Metadata.IsKey()) continue;
```


# 🔍 Configuration

### 1. Enable/disable globally or per module?


✅ **Global Enable exists in _AddEfAuditing registration_**

```
builder.Services.AddEfAuditing<AppDbContext, AuditEntry>();

```

We don't have any disable globally in Configuration Options and we ONLY have per entity in _IAuditEntry_ and _HasId checks_


### 2.  DI Registration Pattern 
 
✅ Yes

Extension method pattern
Generic constraints
coped lifetime 
Factory pattern for IAuditService
Method AddCustomAuditUserProvider 

```
public static IServiceCollection AddEfAuditing<TDbContext, TAuditEntry>(this IServiceCollection services)
{
    services.AddScoped<IAuditUserProvider, DefaultAuditUserProvider>();
    services.AddScoped<EntityAuditingInterceptor<TAuditEntry>>();
    services.AddScoped<IAuditService>(sp => new EfAuditService<x>);
    return services;
}
services.AddCustomAuditUserProvider<MyProvider>();
```
