### PR TITLE
fix: changed validation handling in CrudService

### DIFF
--- a/src/FastCrud.Abstractions/Abstractions/ICrudService.cs
+++ b/src/FastCrud.Abstractions/Abstractions/ICrudService.cs
@@ -5,8 +5,8 @@ namespace FastCrud.Abstractions.Abstractions;
 
 public interface ICrudService<TAgg, TId, TCreateDto, TUpdateDto>
 {
-    Task<TAgg> CreateAsync(TCreateDto input, CancellationToken ct);
-    Task<TAgg> UpdateAsync(TId id, TUpdateDto input, CancellationToken ct);
+    Task<OpResult<TAgg>> CreateAsync(TCreateDto input, CancellationToken ct);
+    Task<OpResult<TAgg>> UpdateAsync(TId id, TUpdateDto input, CancellationToken ct);
     Task DeleteAsync(TId id, CancellationToken ct);
     Task<TAgg?> GetByIdAsync(TId id, CancellationToken ct);
     Task<PagedResult<TOut>> GetListAsync<TOut>(
@@ -14,3 +14,4 @@ public interface ICrudService<TAgg, TId, TCreateDto, TUpdateDto>
         Func<IQueryable<TAgg>, IQueryable<TOut>> projector,
         CancellationToken cancellationToken = default);
 }
+

--- a/src/FastCrud.Abstractions/Abstractions/IModelValidator.cs
+++ b/src/FastCrud.Abstractions/Abstractions/IModelValidator.cs
@@ -2,5 +2,5 @@ namespace FastCrud.Abstractions.Abstractions;
 
 public interface IModelValidator<in T>
 {
-    Task ValidateAsync(T model, CancellationToken cancellationToken);
+    Task<(bool ok, string message)> ValidateAsync(T model, CancellationToken cancellationToken);
 }

--- a/src/FastCrud.Abstractions/Primitives/OpResult.cs
+++ b/src/FastCrud.Abstractions/Primitives/OpResult.cs
@@ -1,0 +1,3 @@
+﻿namespace FastCrud.Abstractions.Primitives;
+
+public record OpResult<TData> (bool Succeeded, string Message , TData? Data = default);

--- a/src/FastCrud.Core/Services/CrudService.cs
+++ b/src/FastCrud.Core/Services/CrudService.cs
@@ -10,21 +10,21 @@ public class CrudService<TAgg, TId, TCreateDto, TUpdateDto>(
         IObjectMapper mapper,
         IEnumerable<IModelValidator<TAgg>> validators,
         IServiceProvider serviceProvider,
-        IQueryEngine queryEngine)
-        : ICrudService<TAgg, TId, TCreateDto, TUpdateDto>
+        IQueryEngine queryEngine) 
+        : ICrudService<TAgg, TId, TCreateDto, TUpdateDto> 
 {
-    public async Task<TAgg> CreateAsync(TCreateDto input, CancellationToken cancellationToken)
+    public async Task<OpResult<TAgg>> CreateAsync(TCreateDto input, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(input);
 
-        await ValidateDtoAsync(input!, serviceProvider, cancellationToken);
-        
+        var (ok, message) = await ValidateDtoAsync(input!, serviceProvider, cancellationToken);
+        if(!ok) return new OpResult<TAgg>(false, message);
         var entity = mapper.Map<TAgg>(input);
 
         await ValidateModelAsync(entity, cancellationToken);
         await repository.AddAsync(entity, cancellationToken);
         await repository.SaveChangesAsync(cancellationToken);
-        return entity;
+        return new OpResult<TAgg>(true, string.Empty, entity);
     }
 
     public async Task DeleteAsync(TId id, CancellationToken cancellationToken)
@@ -44,7 +44,7 @@ public class CrudService<TAgg, TId, TCreateDto, TUpdateDto>(
         CancellationToken ct = default)
             => await queryEngine.ApplyQueryAsync(repository.Query(), spec, projector, ct);
 
-    public async Task<TAgg> UpdateAsync(TId id, TUpdateDto input, CancellationToken ct)
+    public async Task<OpResult<TAgg>> UpdateAsync(TId id, TUpdateDto input, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(input);
         var entity = await repository.FindAsync(id, ct)
@@ -52,23 +52,27 @@ public class CrudService<TAgg, TId, TCreateDto, TUpdateDto>(
 
         mapper.Map(input, entity);
 
-        await ValidateModelAsync(entity, ct);
+        var (ok, message) = await ValidateModelAsync(entity, ct);
+        if(!ok) return new OpResult<TAgg>(false, message);
         await repository.SaveChangesAsync(ct);
-        return entity;
+        return new OpResult<TAgg>(true, string.Empty, entity);
     }
 
 
-    private async Task ValidateModelAsync(
+    private async Task<(bool ok, string message)> ValidateModelAsync(
         TAgg entity,
         CancellationToken cancellationToken)
     {
         foreach (var validator in validators)
         {
-            await validator.ValidateAsync(entity, cancellationToken);
+            var (ok, message) = await validator.ValidateAsync(entity, cancellationToken);
+            if (!ok) return (false, message);
         }
+
+        return (true, string.Empty);
     }
 
-    private static async Task ValidateDtoAsync(
+    private static async Task<(bool ok, string message)> ValidateDtoAsync(
         object dto,
         IServiceProvider serviceProvider,
         CancellationToken cancellationToken)
@@ -78,14 +82,16 @@ public class CrudService<TAgg, TId, TCreateDto, TUpdateDto>(
         var enumerableType = typeof(IEnumerable<>).MakeGenericType(validatorInterface);
 
         if (serviceProvider.GetService(enumerableType) is not IEnumerable validators)
-            return;
+            return (true, string.Empty);
 
         foreach (var v in validators)
         {
             var method = v.GetType().GetMethod("ValidateAsync", [dtoType, typeof(CancellationToken)])!;
-            var task = (Task)method.Invoke(v, [dto, cancellationToken])!;
-            await task.ConfigureAwait(false);
+            var task = (Task<(bool ok, string message)>)method.Invoke(v, [dto, cancellationToken])!;
+            var result = await task.ConfigureAwait(false);
+            if(!result.ok) return (false, result.message);
         }
+        return (true, string.Empty);
     }
 }
 

--- a/src/FastCrud.Validation.FluentValidation/FluentValidationModelValidator.cs
+++ b/src/FastCrud.Validation.FluentValidation/FluentValidationModelValidator.cs
@@ -7,13 +7,15 @@ public sealed class FluentValidationModelValidator<T>(
     IEnumerable<IValidator<T>> validators
 ) : IModelValidator<T>
 {
-    public async Task ValidateAsync(T model, CancellationToken cancellationToken)
+    public async Task<(bool ok, string message)> ValidateAsync(T model, CancellationToken cancellationToken)
     {
         foreach (var validator in validators)
         {
             var result = await validator.ValidateAsync(model, cancellationToken);
             if (!result.IsValid)
-                throw new ValidationException(result.Errors);
+                return (false, result.ToString());
+
         }
+        return (true, string.Empty);
     }
 }

--- a/src/FastCrud.Web.MinimalApi/FastCrudEndpointExtensions.cs
+++ b/src/FastCrud.Web.MinimalApi/FastCrudEndpointExtensions.cs
@@ -58,8 +58,10 @@ public static class FastCrudEndpointExtensions
                 ICrudService<TAgg, TId, TCreateDto, TUpdateDto> svc,
                 CancellationToken cancellationToken) =>
             {
-                var created = await svc.CreateAsync(dto, cancellationToken);
-                return Results.Ok();
+                var opResult = await svc.CreateAsync(dto, cancellationToken);
+                return !opResult.Succeeded 
+                    ? Results.BadRequest(opResult.Message) 
+                    : Results.Created();
             })
             .WithName($"Create{typeof(TAgg).Name}");
         }
@@ -72,8 +74,10 @@ public static class FastCrudEndpointExtensions
                 ICrudService<TAgg, TId, TCreateDto, TUpdateDto> svc,
                 CancellationToken cancellationToken) =>
             {
-                var updated = await svc.UpdateAsync(id, dto, cancellationToken);
-                return Results.Ok();
+                var opResult = await svc.UpdateAsync(id, dto, cancellationToken);
+                return !opResult.Succeeded 
+                    ? Results.BadRequest(opResult.Message) 
+                    : Results.Ok();
             })
             .WithName($"Update{typeof(TAgg).Name}");
         }


### PR DESCRIPTION
## Summary

changed validation handling in `CrudService` to use a Result type pattern. 
Linked Issue: #9 

## Changes

* Added `OpResult` type to pass data from `CrudService` to `FastCrudEndpointExtensions` since they are on two different layers and they have significant data transactions between each other.
* used tuples to pass data from validators to `CrudService`, tuples are descriptive enough and the use-case was not big enough for a type definition, eg `(bool ok, string message)`. The transaction between the validation layer and CrudService layer only needed to deliver a state and a message and no other significant data

now validations are properly handled and set in api response

## Affected

### Operations

* Create
* Update

### Types

* `CrudService`
* `ICrudService`
* `FastCrudEndpointExtensions`
* `IModelValidator`
* `FluentValidationModelValidator`

## Notes

I defined `OpResult` in the abstractions layer and it's a generic type to allow usage in both Create and Update operations. `CrudService` does the validation and returns `OpResult`:

```csharp
        var (ok, message) = await ValidateDtoAsync(input!, serviceProvider, cancellationToken);
        if(!ok) return new OpResult<TAgg>(false, message);
```

Then in `FastCrudEndpointExtensions` where the endpoints are mapped the result is handled for a response:

```csharp
                var opResult = await svc.CreateAsync(dto, cancellationToken);
                return !opResult.Succeeded 
                    ? Results.BadRequest(opResult.Message) 
                    : Results.Created();
```